### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 .DS_Store
 .editorconfig
 .eslintrc
+.node-version
 .git*
 .npmignore
 test/

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@
 .git*
 .npmignore
 test/
+poi.config.js


### PR DESCRIPTION
Ignoring `.node-version`.
@kronicker Should we exclude `poi.config.js` to? 🤔 